### PR TITLE
Add metadata related to Municipality of Valsamoggia

### DIFF
--- a/services.yml
+++ b/services.yml
@@ -390,6 +390,7 @@ azure-deployc49a:
   email: io-testing@teamdigitale.governo.it
   scope: LOCAL
 
+#
 # Municipality of Turin
 #
 01D4AQHBKESFSX98TK52PMD5S3:
@@ -487,9 +488,9 @@ azure-deployc49a:
   email: info@torinofacile.it
   scope: LOCAL
 
+#
 # Municipality of Ripalta Cremasca
 #
-
 01DECE05RF356RDC7QV1DAT2QR:
   description: |
     Il Comune di Ripalta Cremasca partecipa alla closed-beta di IO. 
@@ -558,4 +559,10 @@ azure-deployc49a:
   address: via Roma 5, 26010 Ripalta Cremasca
   phone: 0373 68131
   pec: comune.ripaltacremasca@pec.it
+  scope: LOCAL
+
+#
+# Municipality of Valsamoggia
+#
+5B3F4B1DA9AB400F54DC5AB1C49A:
   scope: LOCAL

--- a/services/5b3f4b1da9ab400f54dc5ab1c49a.json
+++ b/services/5b3f4b1da9ab400f54dc5ab1c49a.json
@@ -1,0 +1,1 @@
+{"scope":"LOCAL"}


### PR DESCRIPTION
This pr introduces the metadata for the service (id: 5B3F4B1DA9AB400F54DC5AB1C49A) provided by the Municipality of Valsamoggia to declare the service as local.

<img width="140" alt="image" src="https://user-images.githubusercontent.com/38431762/63354390-a42bf180-c364-11e9-9a7b-bb9cb7ebd2df.png">
